### PR TITLE
build: bump artemis from 2.6.4 to 2.33.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,15 +34,15 @@ This project leverages the following third party content.
 
 ### Maven Dependencies
 
-* maven/mavencentral/org.apache.activemq/artemis-server/2.42.0, Apache-2.0, approved, #22807
-* maven/mavencentral/org.apache.activemq/artemis-commons/2.42.0, Apache-2.0 AND (Apache-2.0 AND EPL-2.0 AND MIT), approved, #22808
-* maven/mavencentral/org.apache.activemq/artemis-core-client/2.42.0, Apache-2.0, approved, #22809
-* maven/mavencentral/org.apache.activemq/artemis-journal/2.42.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #22810
-* maven/mavencentral/org.apache.activemq/artemis-selector/2.42.0, Apache-2.0, approved, #22811
-* maven/mavencentral/org.apache.activemq/artemis-jms-client/2.42.0, Apache-2.0, approved, #22812
-* maven/mavencentral/org.apache.activemq/artemis-jms-server/2.42.0, Apache-2.0, approved, #22813
-* maven/mavencentral/org.apache.activemq/artemis-service-extensions/2.42.0, Apache-2.0, approved, #22814
-* maven/mavencentral/org.apache.activemq/artemis-lockmanager-api/2.42.0, Apache-2.0, approved, #22815
+* maven/mavencentral/org.apache.activemq/artemis-server/2.33.0, Apache-2.0, approved, #14929
+* maven/mavencentral/org.apache.activemq/artemis-commons/2.33.0, Apache-2.0 AND (BSD-3-Clause AND MIT), approved, #14932
+* maven/mavencentral/org.apache.activemq/artemis-core-client/2.33.0, Apache-2.0, approved, #14918
+* maven/mavencentral/org.apache.activemq/artemis-journal/2.33.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14979
+* maven/mavencentral/org.apache.activemq/artemis-selector/2.33.0, Apache-2.0, approved, #14963
+* maven/mavencentral/org.apache.activemq/artemis-jms-client/2.33.0, Apache-2.0, approved, #14967
+* maven/mavencentral/org.apache.activemq/artemis-jms-server/2.33.0, Apache-2.0, approved, #14962
+* maven/mavencentral/org.apache.activemq/artemis-service-extensions/2.33.0, Apache-2.0, approved, #14934
+* maven/mavencentral/org.apache.activemq/artemis-lockmanager-api/2.33.0, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/jakarta.jms/jakarta.jms-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.messaging
 * maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jta
 * maven/mavencentral/jakarta.enterprise/jakarta.enterprise.cdi-api/4.1.0, Apache-2.0, approved, ee4j.cdi

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -65,11 +65,6 @@ This project leverages the following third party content.
 * maven/mavencentral/com.codahale.metrics/metrics-core/3.0.2, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/com.google.errorprone/error_prone_annotations/2.41.0, Apache-2.0, approved, #22631
 * maven/mavencentral/org.jspecify/jspecify/1.0.0, Apache-2.0, approved, #21897
-* maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.19.2, Apache-2.0, approved, #21909
-* maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.19.2, Apache-2.0, approved, #21911
-* maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.19.2, Apache-2.0 AND MIT, approved, #21916
-* maven/mavencentral/io.netty/netty-codec-socks/4.1.122.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-handler-proxy/4.1.122.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 * maven/mavencentral/commons-beanutils/commons-beanutils/1.11.0, Apache-2.0, approved, #21555
 * maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 * maven/mavencentral/org.apache.commons/commons-text/1.13.0, Apache-2.0, approved, #17931

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,21 +34,48 @@ This project leverages the following third party content.
 
 ### Maven Dependencies
 
-* maven/mavencentral/org.apache.activemq/artemis-server/2.6.4, Apache-2.0, approved, CQ19068
-* maven/mavencentral/org.apache.activemq/artemis-commons/2.6.4, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ19066
-* maven/mavencentral/org.apache.activemq/artemis-core-client/2.6.4, Apache-2.0, approved, CQ19072
-* maven/mavencentral/org.apache.activemq/artemis-jms-client/2.6.4, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.activemq/artemis-jms-server/2.6.4, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.activemq/artemis-journal/2.6.4, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.activemq/artemis-selector/2.6.4, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.activemq/artemis-service-extensions/2.6.4, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.activemq/artemis-mqtt-protocol/2.6.4, Apache-2.0, approved, #3086
-* maven/mavencentral/org.apache.activemq/artemis-native/2.6.4, Apache-2.0, approved, CQ19010
-* maven/mavencentral/org.jboss.logging/jboss-logging/3.6.1.Final, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/org.apache.geronimo.specs/geronimo-json_1.0_spec/1.0-alpha-1, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/org.apache.activemq/artemis-server/2.42.0, Apache-2.0, approved, #22807
+* maven/mavencentral/org.apache.activemq/artemis-commons/2.42.0, Apache-2.0 AND (Apache-2.0 AND EPL-2.0 AND MIT), approved, #22808
+* maven/mavencentral/org.apache.activemq/artemis-core-client/2.42.0, Apache-2.0, approved, #22809
+* maven/mavencentral/org.apache.activemq/artemis-journal/2.42.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #22810
+* maven/mavencentral/org.apache.activemq/artemis-selector/2.42.0, Apache-2.0, approved, #22811
+* maven/mavencentral/org.apache.activemq/artemis-jms-client/2.42.0, Apache-2.0, approved, #22812
+* maven/mavencentral/org.apache.activemq/artemis-jms-server/2.42.0, Apache-2.0, approved, #22813
+* maven/mavencentral/org.apache.activemq/artemis-service-extensions/2.42.0, Apache-2.0, approved, #22814
+* maven/mavencentral/org.apache.activemq/artemis-lockmanager-api/2.42.0, Apache-2.0, approved, #22815
+* maven/mavencentral/jakarta.jms/jakarta.jms-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.messaging
+* maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jta
+* maven/mavencentral/jakarta.enterprise/jakarta.enterprise.cdi-api/4.1.0, Apache-2.0, approved, ee4j.cdi
+* maven/mavencentral/jakarta.interceptor/jakarta.interceptor-api/2.2.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.interceptors
+* maven/mavencentral/jakarta.el/jakarta.el-api/6.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.el
+* maven/mavencentral/jakarta.enterprise/jakarta.enterprise.lang-model/4.1.0, Apache-2.0, approved, ee4j.cdi
+* maven/mavencentral/javax.persistence/javax.persistence-api/2.2, BSD-3-Clause, approved, #280
 * maven/mavencentral/org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1, Apache-2.0, approved, CQ2334
-* maven/mavencentral/commons-beanutils/commons-beanutils/1.11.0, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
+* maven/mavencentral/org.apache.commons/commons-configuration2/2.12.0, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/io.micrometer/micrometer-core/1.15.2, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/io.micrometer/micrometer-commons/1.15.2, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/io.micrometer/micrometer-observation/1.15.2, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, CC0-1.0, approved, #15280
+* maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
+* maven/mavencentral/de.dentrassi.crypto/pem-keystore/3.0.0, Apache-2.0 AND EPL-1.0, approved, clearlydefined
+* maven/mavencentral/com.hierynomus/asn-one/0.6.0, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/org.jctools/jctools-core/4.0.5, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/org.jgroups/jgroups/5.4.8.Final, Apache-2.0 AND CC-BY-2.5, approved, #22816
+* maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.2.2, Apache-2.0 AND (Apache-2.0 AND CC0-1.0), approved, #18889
+* maven/mavencentral/com.codahale.metrics/metrics-core/3.0.2, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/com.google.errorprone/error_prone_annotations/2.41.0, Apache-2.0, approved, #22631
+* maven/mavencentral/org.jspecify/jspecify/1.0.0, Apache-2.0, approved, #21897
+* maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.19.2, Apache-2.0, approved, #21909
+* maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.19.2, Apache-2.0, approved, #21911
+* maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.19.2, Apache-2.0 AND MIT, approved, #21916
+* maven/mavencentral/io.netty/netty-codec-socks/4.1.122.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-handler-proxy/4.1.122.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/commons-beanutils/commons-beanutils/1.11.0, Apache-2.0, approved, #21555
+* maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
+* maven/mavencentral/org.apache.commons/commons-text/1.13.0, Apache-2.0, approved, #17931
+* maven/mavencentral/commons-logging/commons-logging/1.3.5, Apache-2.0, approved, #11783
+* maven/mavencentral/org.apache.activemq/activemq-artemis-native/2.0.0, Apache-2.0 AND (Apache-2.0 AND EPL-1.0 AND MIT), approved, #6739
+* maven/mavencentral/org.apache.activemq/artemis-mqtt-protocol/2.42.0, Apache-2.0, approved, #22817
 
 ## Cryptography
 

--- a/bundles/org.apache.activemq.artemis/pom.xml
+++ b/bundles/org.apache.activemq.artemis/pom.xml
@@ -32,6 +32,7 @@
     <description>ActiveMQ Artemis dependencies for Eclipse Kura</description>
 
     <dependencies>
+        <!-- START artemis deps -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-server</artifactId>
@@ -46,14 +47,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-jms-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-jms-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-journal</artifactId>
         </dependency>
         <dependency>
@@ -62,8 +55,133 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-service-extensions</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-lockmanager-api</artifactId>
+        </dependency>
+        <!-- END artemis deps -->
+         <!-- START jakarta deps -->
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.lang-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+        </dependency>
+        <!-- END jakarta deps -->
+        <!-- START transitive deps -->
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.latencyutils</groupId>
+            <artifactId>LatencyUtils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.dentrassi.crypto</groupId>
+            <artifactId>pem-keystore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hierynomus</groupId>
+            <artifactId>asn-one</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jgroups</groupId>
+            <artifactId>jgroups</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+        </dependency>
+        <!-- END transitive deps -->
     </dependencies>
 
     <build>
@@ -76,13 +194,41 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>*</Embed-Dependency>
+                        <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
                         <Import-Package>
                             org.apache.activemq.artemis.jdbc.store.*;version="${org.apache.activemq.artemis.upstream.version}";resolution:=optional,
                             org.apache.xpath.*;resolution:=optional,
-                            org.jboss.logmanager;resolution:=optional,
-                            org.jboss.logmanager.*;resolution:=optional,
-                            org.jgroups.*;resolution:=optional,
+                            org.apache.commons.text,
+                            org.apache.commons.lang3,
+                            <!-- START micrometer-core optional dependencies -->
+                            !ch.qos.logback.*,
+                            !com.mongodb.*,
+                            !com.netflix.hystrix.*,
+                            !io.grpc.*,
+                            !kotlin.*,
+                            !kotlinx.coroutines.*,
+                            !io.micrometer.context.*,
+                            !javax.cache.*,
+                            !net.sf.ehcache.*,
+                            !okhttp3.*,
+                            !org.apache.catalina.*,
+                            !org.apache.hc.client5.http.*,
+                            !org.apache.hc.core5.concurrent.*,
+                            !org.apache.hc.core5.http.*,
+                            !org.apache.hc.core5.pool.*,
+                            !org.apache.hc.core5.util.*,
+                            !org.apache.http.*,
+                            !org.apache.kafka.*,
+                            !org.aspectj.*,
+                            !org.bson.*,
+                            !org.eclipse.jetty.client.api.*,
+                            !org.eclipse.jetty.server.api.*,
+                            !org.glassfish.json.*,
+                            !org.hibernate.*,
+                            !org.jooq.*,
+                            !rx.*,
+                            javax.xml.bind.*;resolution:=optional,
+                            <!-- END micrometer-core optional dependencies -->
                             *
                         </Import-Package>
                         <Export-Package>

--- a/bundles/org.apache.activemq.artemis/pom.xml
+++ b/bundles/org.apache.activemq.artemis/pom.xml
@@ -161,26 +161,6 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-socks</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-        </dependency>
         <!-- END transitive deps -->
     </dependencies>
 

--- a/bundles/org.eclipse.kura.broker.artemis.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.kura.broker.artemis.core/META-INF/MANIFEST.MF
@@ -7,14 +7,14 @@ Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-ActivationPolicy: lazy
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.activemq.artemis.core.config;version="2.6.0",
- org.apache.activemq.artemis.core.config.impl;version="2.6.0",
- org.apache.activemq.artemis.core.deployers;version="2.6.0",
- org.apache.activemq.artemis.core.server;version="2.6.0",
- org.apache.activemq.artemis.jms.server.config.impl;version="2.6.0",
- org.apache.activemq.artemis.spi.core.protocol;version="2.6.0",
- org.apache.activemq.artemis.spi.core.security;version="2.6.0",
- org.apache.activemq.artemis.spi.core.security.jaas;version="2.6.0",
+Import-Package: org.apache.activemq.artemis.core.config;version="2.42.0",
+ org.apache.activemq.artemis.core.config.impl;version="2.42.0",
+ org.apache.activemq.artemis.core.deployers;version="2.42.0",
+ org.apache.activemq.artemis.core.server;version="2.42.0",
+ org.apache.activemq.artemis.jms.server.config.impl;version="2.42.0",
+ org.apache.activemq.artemis.spi.core.protocol;version="2.42.0",
+ org.apache.activemq.artemis.spi.core.security;version="2.42.0",
+ org.apache.activemq.artemis.spi.core.security.jaas;version="2.42.0",
  org.eclipse.kura.configuration;version="[1.1,2.0)",
  org.osgi.framework;version="1.8",
  org.osgi.util.tracker;version="1.5",

--- a/bundles/org.eclipse.kura.broker.artemis.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.kura.broker.artemis.core/META-INF/MANIFEST.MF
@@ -7,14 +7,14 @@ Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-ActivationPolicy: lazy
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
-Import-Package: org.apache.activemq.artemis.core.config;version="2.42.0",
- org.apache.activemq.artemis.core.config.impl;version="2.42.0",
- org.apache.activemq.artemis.core.deployers;version="2.42.0",
- org.apache.activemq.artemis.core.server;version="2.42.0",
- org.apache.activemq.artemis.jms.server.config.impl;version="2.42.0",
- org.apache.activemq.artemis.spi.core.protocol;version="2.42.0",
- org.apache.activemq.artemis.spi.core.security;version="2.42.0",
- org.apache.activemq.artemis.spi.core.security.jaas;version="2.42.0",
+Import-Package: org.apache.activemq.artemis.core.config;version="[2.33,3.0)",
+ org.apache.activemq.artemis.core.config.impl;version="[2.33,3.0)",
+ org.apache.activemq.artemis.core.deployers;version="[2.33,3.0)",
+ org.apache.activemq.artemis.core.server;version="[2.33,3.0)",
+ org.apache.activemq.artemis.jms.server.config.impl;version="[2.33,3.0)",
+ org.apache.activemq.artemis.spi.core.protocol;version="[2.33,3.0)",
+ org.apache.activemq.artemis.spi.core.security;version="[2.33,3.0)",
+ org.apache.activemq.artemis.spi.core.security.jaas;version="[2.33,3.0)",
  org.eclipse.kura.configuration;version="[1.1,2.0)",
  org.osgi.framework;version="1.8",
  org.osgi.util.tracker;version="1.5",

--- a/bundles/org.eclipse.kura.broker.artemis.core/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.core/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.apache.activemq.artemis</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     

--- a/bundles/org.eclipse.kura.broker.artemis.core/src/main/java/org/eclipse/kura/broker/artemis/core/ServerRunner.java
+++ b/bundles/org.eclipse.kura.broker.artemis.core/src/main/java/org/eclipse/kura/broker/artemis/core/ServerRunner.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Red Hat Inc and others
- * 
+ * Copyright (c) 2017, 2025 Red Hat Inc and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Red Hat Inc
  *  Eurotech
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
+import org.apache.activemq.artemis.core.server.ActivateCallback;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.server.config.impl.FileJMSConfiguration;
@@ -85,7 +86,9 @@ public class ServerRunner {
 
         // load components
 
-        this.components = fileDeploymentManager.buildService(security, ManagementFactory.getPlatformMBeanServer());
+        this.components = fileDeploymentManager.buildService(security, ManagementFactory.getPlatformMBeanServer(),
+                new ActivateCallback() {
+                });
 
         logger.info("Loaded components: {}", this.components.size());
         for (final Map.Entry<String, ActiveMQComponent> entry : this.components.entrySet()) {

--- a/bundles/org.eclipse.kura.broker.artemis.simple.mqtt/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.simple.mqtt/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.apache.activemq.artemis</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/bundles/org.eclipse.kura.broker.artemis.xml/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.xml/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.apache.activemq.artemis</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -31,26 +31,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-mqtt-protocol</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-native</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.0_spec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
@@ -58,11 +38,21 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
-        <!-- External deps in common with Camel, available in kura-target-platform -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jms_2.0_spec</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-artemis-native</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-mqtt-protocol</artifactId>
         </dependency>
         <!-- This project's bundles -->
         <dependency>
@@ -228,12 +218,11 @@
                         </goals>
                         <configuration>
                             <includeArtifactIds>
-                                artemis-native,
-                                jboss-logging,
-                                geronimo-json_1.0_spec,
-                                geronimo-jta_1.1_spec,
+                                activemq-artemis-native,
                                 commons-beanutils,
                                 commons-collections,
+                                commons-text,
+                                commons-logging,
                                 org.apache.activemq.artemis
                             </includeArtifactIds>
                             <excludeTransitive>true</excludeTransitive>
@@ -251,6 +240,7 @@
                             <includeArtifactIds>
                                 artemis-mqtt-protocol
                             </includeArtifactIds>
+                            <excludeTransitive>true</excludeTransitive>
                             <stripVersion>false</stripVersion>
                             <outputDirectory>${project.build.directory}/plugins_3s</outputDirectory>
                         </configuration>

--- a/kura-artemis-bom/pom.xml
+++ b/kura-artemis-bom/pom.xml
@@ -290,72 +290,72 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_2.0_spec</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-epoll</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-kqueue</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-classes-kqueue</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/kura-artemis-bom/pom.xml
+++ b/kura-artemis-bom/pom.xml
@@ -32,7 +32,15 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- External deps that are not OSGi bundles, that will be wrapped by our bundle -->
+            <dependency>
+                <groupId>org.eclipse.kura</groupId>
+                <artifactId>target-platform-bom</artifactId>
+                <version>6.0.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- External deps that are not OSGi bundles, that will be wrapped by our org.apache.activemq.artemis bundle -->
+            <!-- START artemis deps -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-server</artifactId>
@@ -50,16 +58,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-jms-client</artifactId>
-                <version>${org.apache.activemq.artemis.upstream.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-jms-server</artifactId>
-                <version>${org.apache.activemq.artemis.upstream.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-journal</artifactId>
                 <version>${org.apache.activemq.artemis.upstream.version}</version>
             </dependency>
@@ -70,52 +68,197 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jms-client</artifactId>
+                <version>${org.apache.activemq.artemis.upstream.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jms-server</artifactId>
+                <version>${org.apache.activemq.artemis.upstream.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-service-extensions</artifactId>
                 <version>${org.apache.activemq.artemis.upstream.version}</version>
             </dependency>
-            <!-- External deps that are OSGi bundles, that do not need wrapping in an eclipse kura
-            bundle -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-mqtt-protocol</artifactId>
+                <artifactId>artemis-lockmanager-api</artifactId>
                 <version>${org.apache.activemq.artemis.upstream.version}</version>
             </dependency>
+            <!-- END artemis deps -->
+            <!-- START jakarta deps -->
             <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-native</artifactId>
-                <version>${org.apache.activemq.artemis.upstream.version}</version>
+                <groupId>jakarta.jms</groupId>
+                <artifactId>jakarta.jms-api</artifactId>
+                <version>${jakarta.jms-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${jboss.logging.version}</version>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.geronimo.specs</groupId>
-                <artifactId>geronimo-json_1.0_spec</artifactId>
-                <version>${geronimo.json.version}</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.lang-model</artifactId>
+                <version>${jakarta.enterprise.lang-model.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.persistence</groupId>
+                <artifactId>javax.persistence-api</artifactId>
+                <version>${javax.persistence-api.version}</version>
+            </dependency>
+            <!-- END jakarta deps -->
+            <!-- START transitive deps -->
             <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-jta_1.1_spec</artifactId>
                 <version>${geronimo.jta.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons-configuration2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-commons</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-observation</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.latencyutils</groupId>
+                <artifactId>LatencyUtils</artifactId>
+                <version>${LatencyUtils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${HdrHistogram.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.dentrassi.crypto</groupId>
+                <artifactId>pem-keystore</artifactId>
+                <version>${pem-keystore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hierynomus</groupId>
+                <artifactId>asn-one</artifactId>
+                <version>${asn-one.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jctools</groupId>
+                <artifactId>jctools-core</artifactId>
+                <version>${jctools-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jgroups</groupId>
+                <artifactId>jgroups</artifactId>
+                <version>${jgroups.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.codahale.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${metrics-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${error_prone_annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
+            </dependency>
+            <!-- TODO: maybe this needs to be added in Kura target platform -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <!-- TODO: maybe these netty ones have to be added in Kura target platform -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-socks</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <!-- END transitive deps -->
+            <!-- External deps that are OSGi bundles, that do not need wrapping in an eclipse kura
+            bundle -->
+            <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>${commons.beanutils.version}</version>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>${commons.collections.version}</version>
+                <version>${commons-collections.version}</version>
             </dependency>
-            <!-- External deps in common with Camel, available in kura-target-platform -->
             <dependency>
-                <groupId>org.apache.geronimo.specs</groupId>
-                <artifactId>geronimo-jms_2.0_spec</artifactId>
-                <version>${geronimo.jms.version}</version>
-                <scope>provided</scope>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-artemis-native</artifactId>
+                <version>${activemq-artemis-native.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-mqtt-protocol</artifactId>
+                <version>${org.apache.activemq.artemis.upstream.version}</version>
             </dependency>
             <!-- This project's bundles -->
             <dependency>
@@ -143,32 +286,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-mqtt-protocol</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-native</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.0_spec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
@@ -185,6 +312,77 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.broker.artemis.xml</artifactId>
+        </dependency>
+        <!-- External deps available in kura-target-platform -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-kqueue</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/kura-artemis-bom/pom.xml
+++ b/kura-artemis-bom/pom.xml
@@ -200,33 +200,6 @@
                 <artifactId>jspecify</artifactId>
                 <version>${jspecify.version}</version>
             </dependency>
-            <!-- TODO: maybe this needs to be added in Kura target platform -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <!-- TODO: maybe these netty ones have to be added in Kura target platform -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-socks</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler-proxy</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
             <!-- END transitive deps -->
             <!-- External deps that are OSGi bundles, that do not need wrapping in an eclipse kura
             bundle -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,6 @@
         <error_prone_annotations.version>2.41.0</error_prone_annotations.version>
         <jspecify.version>1.0.0</jspecify.version>
 
-        <jackson.version>2.19.2</jackson.version> <!-- Match with jackson deps version in Kura target platform -->
-        <netty.version>4.1.122.Final</netty.version> <!-- Match with netty deps version in Kura target platform -->
-
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-text.version>1.13.0</commons-text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <org.apache.activemq.artemis.upstream.version>2.42.0</org.apache.activemq.artemis.upstream.version>
+        <org.apache.activemq.artemis.upstream.version>2.33.0</org.apache.activemq.artemis.upstream.version>
         
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,37 @@
     <packaging>pom</packaging>
 
     <properties>
-        <org.apache.activemq.artemis.upstream.version>2.6.4</org.apache.activemq.artemis.upstream.version>
-        <jboss.logging.version>3.6.1.Final</jboss.logging.version>
-        <geronimo.json.version>1.0-alpha-1</geronimo.json.version>
+        <org.apache.activemq.artemis.upstream.version>2.42.0</org.apache.activemq.artemis.upstream.version>
+        
+        <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
+        <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
+        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
+        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
+        <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
+        <jakarta.enterprise.lang-model.version>4.1.0</jakarta.enterprise.lang-model.version>
+        <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <geronimo.jta.version>1.1.1</geronimo.jta.version>
-        <geronimo.jms.version>1.0-alpha-2</geronimo.jms.version>
-        <commons.beanutils.version>1.11.0</commons.beanutils.version>
-        <commons.collections.version>3.2.2</commons.collections.version>
+        <commons-configuration2.version>2.12.0</commons-configuration2.version>
+        <micrometer.version>1.15.2</micrometer.version>
+        <LatencyUtils.version>2.0.3</LatencyUtils.version>
+        <HdrHistogram.version>2.2.2</HdrHistogram.version>
+        <pem-keystore.version>3.0.0</pem-keystore.version>
+        <asn-one.version>0.6.0</asn-one.version>
+        <jctools-core.version>4.0.5</jctools-core.version>
+        <jgroups.version>5.4.8.Final</jgroups.version>
+        <caffeine.version>3.2.2</caffeine.version>
+        <metrics-core.version>3.0.2</metrics-core.version>
+        <error_prone_annotations.version>2.41.0</error_prone_annotations.version>
+        <jspecify.version>1.0.0</jspecify.version>
+
+        <jackson.version>2.19.2</jackson.version> <!-- Match with jackson deps version in Kura target platform -->
+        <netty.version>4.1.122.Final</netty.version> <!-- Match with netty deps version in Kura target platform -->
+
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-text.version>1.13.0</commons-text.version>
+        <commons-logging.version>1.3.5</commons-logging.version>
+        <activemq-artemis-native.version>2.0.0</activemq-artemis-native.version>
 
         <org.apache.activemq.artemis.kura.wrapper.version>3.0.0-SNAPSHOT</org.apache.activemq.artemis.kura.wrapper.version>
         <org.eclipse.kura.broker.artemis.core.version>2.0.0-SNAPSHOT</org.eclipse.kura.broker.artemis.core.version>


### PR DESCRIPTION
This PR updates Artemis dependencies from 2.6.4 to 2.33.0. Adds transitive dependencies and updates `distrib` build accordingly.

**Related Issue:** IP review requests for new dependencies:

- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22807
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22808
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22809
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22810
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22811
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22812
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22813
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22814
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22815
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22816
- https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22817

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
