### PR TITLE
ci(workflows): add SBOM generation & upload

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,28 @@
+name: Kura SBOM upload
+
+on:
+  schedule:
+    # At 00:00 on Sunday
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+    inputs:
+        target_branch:
+          type: string
+          default: 'develop'
+          required: true
+  workflow_run:
+    workflows: ["Release Notes automation"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  call-workflow-in-public-repo:
+    uses: eclipse-kura/.github/.github/workflows/_shared-sbom-cyclonedx.yml@main
+    with:
+      # The parent project UUID the uploaded SBOM should be associated with.
+      # Refer to https://sbom.eclipse.org/ to retrieve the UUID.
+      dependency-track-id: 'f86fd882-329a-43a5-93bb-2a5035464b41'


### PR DESCRIPTION
Add SBOM generation & upload workflow leveraging reusable workflow introduced in https://github.com/eclipse-kura/.github/pull/14