### PR TITLE
build: uptick version to greatest jar version

### DIFF
--- a/bundles/org.apache.activemq.artemis/pom.xml
+++ b/bundles/org.apache.activemq.artemis/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.apache.activemq.artemis</artifactId>

--- a/bundles/org.eclipse.kura.broker.artemis.core/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.eclipse.kura.broker.artemis.core</artifactId>

--- a/bundles/org.eclipse.kura.broker.artemis.simple.mqtt/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.simple.mqtt/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.eclipse.kura.broker.artemis.simple.mqtt</artifactId>

--- a/bundles/org.eclipse.kura.broker.artemis.xml/pom.xml
+++ b/bundles/org.eclipse.kura.broker.artemis.xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.eclipse.kura.broker.artemis.xml</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.kura</groupId>

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../bundles/pom.xml</relativePath>
     </parent>
 

--- a/kura-artemis-bom/pom.xml
+++ b/kura-artemis-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.kura</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.eclipse.kura</groupId>
     <artifactId>kura-artemis</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/target-definition/pom.xml
+++ b/target-definition/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../bundles/pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.kura</groupId>
         <artifactId>kura-artemis.parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../bundles/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This PR upticks the pom versions to 3.0.0-SNAPSHOT, which corresponds to the greatest version among all the JARs that are bundled by this addon.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
